### PR TITLE
fix(headers): drop x-forwarded-for

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,6 +63,10 @@ func main() {
 		req.URL.Host = viper.GetString("domain")
 		req.Header.Set("Connection", "close")
 
+		// delete x-forwarded-for since the request
+		// signing doesn't like it
+		req.Header.Del("X-Forwarded-For")
+
 		t := time.Now()
 		req.Header.Set("Date", t.Format(time.RFC3339))
 


### PR DESCRIPTION
the aws requests signing process doesn't like the x-forwarded-for header
being included and causes a mismatch when validating the signature. this
would prevent using es-proxy behind some ELB or routing service that
adds these headers.